### PR TITLE
Relaxes Locked AMS Version Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'active_model_serializers', github: 'rails-api/active_model_serializers', branch: '0-9-stable'
 gem 'spree', github: 'spree/spree', branch: '2-4-stable'
 
 group :test do

--- a/spree_wombat.gemspec
+++ b/spree_wombat.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = '2.2.0'
 
   gem.add_dependency 'spree_core', '~> 2.4.0.rc4'
-  gem.add_dependency 'active_model_serializers', '0.9.0.alpha1'
+  gem.add_dependency 'active_model_serializers', '~> 0.9.0'
   gem.add_dependency 'httparty'
 
   gem.add_development_dependency 'capybara', '~> 2.1'


### PR DESCRIPTION
Strictly pinning active_model_serializers to 0.9.0.alpha1 precludes absorbing changes to the 0.9.x branch of the project (such as serialization context, which is really handy).

Relaxing the version dependency doesn't break the test suite, and my (albeit limited) real-world testing hasn't revealed any discrepancies.

Any concerns with merging this into the 2-4-stable branch? Prefer I rebase this against master and cherry-pick into the stable branches?
